### PR TITLE
Update dynamicPermission.Groups.SyncExample.ps1

### DIFF
--- a/dynamicPermission.Groups.SyncExample.ps1
+++ b/dynamicPermission.Groups.SyncExample.ps1
@@ -109,7 +109,7 @@ foreach($permission in $desiredPermissions.GetEnumerator()) {
         $auditLogs.Add([PSCustomObject]@{
             Action = "GrantDynamicPermission";
             Message = "Granted access to department share $($permission.Value)";
-            IsError = $permissionSuccess;
+            IsError = !$permissionSuccess;
         });
     }    
 }


### PR DESCRIPTION
The final $auditLogs.Add call has an incorrect assignment for 'IsError' where the true state is inverted from the assigned value for $permissionSuccess