### PR TITLE
Add Try/Catch Logic to PDC Looup

### DIFF
--- a/AutomationTasks/DeleteDisabledUsers/task.ps1
+++ b/AutomationTasks/DeleteDisabledUsers/task.ps1
@@ -10,7 +10,14 @@ $config = @{
 }
 
 #Get PDC
-$pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+try{
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
+catch {
+    Write-Warning ("PDC Lookup Error: {0}" -f $_.Exception.InnerException.Message)
+    Write-Warning "Retrying PDC Lookup"
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
 
 #endregion Configuration
 

--- a/create.ps1
+++ b/create.ps1
@@ -9,7 +9,14 @@ $success = $False
 $auditLogs = New-Object Collections.Generic.List[PSCustomObject];
 
 #Get Primary Domain Controller
-$pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+try{
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
+catch {
+    Write-Warning ("PDC Lookup Error: {0}" -f $_.Exception.InnerException.Message)
+    Write-Warning "Retrying PDC Lookup"
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
 #endregion Initialize default properties
 
 #region Support Functions

--- a/dynamicPermission.Directory.HomeDirectory.ReferenceExample.ps1
+++ b/dynamicPermission.Directory.HomeDirectory.ReferenceExample.ps1
@@ -20,7 +20,14 @@ $success = $True
 $auditLogs = New-Object Collections.Generic.List[PSCustomObject]
 $dynamicPermissions = New-Object Collections.Generic.List[PSCustomObject]
 
-$pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+try{
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
+catch {
+    Write-Warning ("PDC Lookup Error: {0}" -f $_.Exception.InnerException.Message)
+    Write-Warning "Retrying PDC Lookup"
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
 $server = "HelloID001"
 $path = "HelloID\Home"
 $archivePath = "HelloID\Home\_Archief"

--- a/dynamicPermission.Directory.ProfilePath.ReferenceExample.ps1
+++ b/dynamicPermission.Directory.ProfilePath.ReferenceExample.ps1
@@ -20,7 +20,14 @@ $success = $True
 $auditLogs = New-Object Collections.Generic.List[PSCustomObject]
 $dynamicPermissions = New-Object Collections.Generic.List[PSCustomObject]
 
-$pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+try{
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
+catch {
+    Write-Warning ("PDC Lookup Error: {0}" -f $_.Exception.InnerException.Message)
+    Write-Warning "Retrying PDC Lookup"
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
 $server = "HelloID001"
 $path = "HelloID\Profile"
 $archivePath = "HelloID\Profile\_Archief"

--- a/dynamicPermission.Directory.TsHomeDirectory.ReferenceExample.ps1
+++ b/dynamicPermission.Directory.TsHomeDirectory.ReferenceExample.ps1
@@ -20,7 +20,14 @@ $success = $True
 $auditLogs = New-Object Collections.Generic.List[PSCustomObject]
 $dynamicPermissions = New-Object Collections.Generic.List[PSCustomObject]
 
-$pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+try{
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
+catch {
+    Write-Warning ("PDC Lookup Error: {0}" -f $_.Exception.InnerException.Message)
+    Write-Warning "Retrying PDC Lookup"
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
 $server = "HelloID001"
 $path = "HelloID\TsHome"
 $archivePath = "HelloID\TsHome\_Archief"

--- a/dynamicPermission.Directory.TsProfilePath.ReferenceExample.ps1
+++ b/dynamicPermission.Directory.TsProfilePath.ReferenceExample.ps1
@@ -20,7 +20,14 @@ $success = $True
 $auditLogs = New-Object Collections.Generic.List[PSCustomObject]
 $dynamicPermissions = New-Object Collections.Generic.List[PSCustomObject]
 
-$pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+try{
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
+catch {
+    Write-Warning ("PDC Lookup Error: {0}" -f $_.Exception.InnerException.Message)
+    Write-Warning "Retrying PDC Lookup"
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
 $server = "HelloID001"
 $path = "HelloID\TsProfile"
 $archivePath = "HelloID\TsProfile\_Archief"

--- a/dynamicPermission.Groups.ReferenceExample.ps1
+++ b/dynamicPermission.Groups.ReferenceExample.ps1
@@ -12,7 +12,14 @@ $success = $True
 $auditLogs = New-Object Collections.Generic.List[PSCustomObject];
 $dynamicPermissions = New-Object Collections.Generic.List[PSCustomObject];
 
-$pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+try{
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
+catch {
+    Write-Warning ("PDC Lookup Error: {0}" -f $_.Exception.InnerException.Message)
+    Write-Warning "Retrying PDC Lookup"
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
 
 #region Supporting Functions
 function Get-ADSanitizeGroupName

--- a/dynamicPermission.Groups.SyncExample.ps1
+++ b/dynamicPermission.Groups.SyncExample.ps1
@@ -12,7 +12,14 @@ $success = $True
 $auditLogs = New-Object Collections.Generic.List[PSCustomObject];
 $dynamicPermissions = New-Object Collections.Generic.List[PSCustomObject];
 
-$pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+try{
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
+catch {
+    Write-Warning ("PDC Lookup Error: {0}" -f $_.Exception.InnerException.Message)
+    Write-Warning "Retrying PDC Lookup"
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
 #endregion Initialize default properties
 
 #region Supporting Functions

--- a/orgUnit.DefaultOUFallback.ps1
+++ b/orgUnit.DefaultOUFallback.ps1
@@ -6,7 +6,14 @@ $ma = $managerAccountReference | ConvertFrom-Json
 $success = $false
 
 #Get Primary Domain Controller
-$pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+try{
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
+catch {
+    Write-Warning ("PDC Lookup Error: {0}" -f $_.Exception.InnerException.Message)
+    Write-Warning "Retrying PDC Lookup"
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
 #endregion Initialize default properties
 
 #region Change mapping here

--- a/resources.Groups.ReferenceExample.ps1
+++ b/resources.Groups.ReferenceExample.ps1
@@ -5,7 +5,14 @@ $success = $false
 $auditLogs = New-Object Collections.Generic.List[PSCustomObject]
 
 #Get Primary Domain Controller
-$pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+try{
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
+catch {
+    Write-Warning ("PDC Lookup Error: {0}" -f $_.Exception.InnerException.Message)
+    Write-Warning "Retrying PDC Lookup"
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
 Write-Information "Using PDC [$pdc]"
 
 # In preview only the first 10 items of the SourceData are used

--- a/update.ps1
+++ b/update.ps1
@@ -9,7 +9,14 @@ $aRef = $accountReference | ConvertFrom-Json;
 $success = $False
 $auditLogs = New-Object Collections.Generic.List[PSCustomObject];
 
-$pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+try{
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
+catch {
+    Write-Warning ("PDC Lookup Error: {0}" -f $_.Exception.InnerException.Message)
+    Write-Warning "Retrying PDC Lookup"
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
 #endregion Initialize default properties
 
 #region Execute


### PR DESCRIPTION
Add Try/Catch logic around PDC Lookup.  This is needed in some instances where new Agent Powershell sessions fail their first AD Calls.