### PR TITLE
Add Try/Catch Logic to PDC

### DIFF
--- a/dynamicPermission.HomeDirectory.ps1
+++ b/dynamicPermission.HomeDirectory.ps1
@@ -28,7 +28,14 @@ foreach($permission in $eRef.CurrentPermissions) {
 # Determine all the sub-permissions that needs to be Granted/Updated/Revoked
 $subPermissions = New-Object Collections.Generic.List[PSCustomObject]
 
-$pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+try{
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
+catch {
+    Write-Warning ("PDC Lookup Error: {0}" -f $_.Exception.InnerException.Message)
+    Write-Warning "Retrying PDC Lookup"
+    $pdc = (Get-ADForest | Select-Object -ExpandProperty RootDomain | Get-ADDomain | Select-Object -Property PDCEmulator).PDCEmulator
+}
 #endregion Initialize default properties
 
 #region Support Functions


### PR DESCRIPTION
Add Try/Catch logic around PDC Lookup. This is needed in some instances where new Agent Powershell sessions fail their first AD Calls.